### PR TITLE
Drop ProtectionManager owner uuid usages

### DIFF
--- a/Nova/src/main/kotlin/xyz/xenondevs/nova/integration/protection/ProtectionManager.kt
+++ b/Nova/src/main/kotlin/xyz/xenondevs/nova/integration/protection/ProtectionManager.kt
@@ -7,15 +7,11 @@ import xyz.xenondevs.nova.integration.Integration
 import xyz.xenondevs.nova.integration.protection.plugin.*
 import xyz.xenondevs.nova.tileentity.TileEntity
 import xyz.xenondevs.nova.util.isBetweenXZ
-import java.util.*
 
 object ProtectionManager {
     
     private val PROTECTION_PLUGINS = listOf(GriefPrevention, PlotSquared, WorldGuard, GriefDefender, Towny, EventIntegration)
         .filter(Integration::isInstalled)
-    
-    fun canPlace(uuid: UUID, location: Location) =
-        canPlace(Bukkit.getOfflinePlayer(uuid), location)
     
     fun canPlace(tileEntity: TileEntity, location: Location) =
         canPlace(tileEntity.owner, location)
@@ -23,20 +19,14 @@ object ProtectionManager {
     fun canPlace(offlinePlayer: OfflinePlayer, location: Location) =
         !isVanillaProtected(offlinePlayer, location)
             && PROTECTION_PLUGINS.all { it.canPlace(offlinePlayer, location) }
-    
-    fun canBreak(uuid: UUID, location: Location) =
-        canBreak(Bukkit.getOfflinePlayer(uuid), location)
-    
+
     fun canBreak(tileEntity: TileEntity, location: Location) =
         canBreak(tileEntity.owner, location)
     
     fun canBreak(offlinePlayer: OfflinePlayer, location: Location) =
         !isVanillaProtected(offlinePlayer, location)
             && PROTECTION_PLUGINS.all { it.canBreak(offlinePlayer, location) }
-    
-    fun canUse(uuid: UUID, location: Location) =
-        canUse(Bukkit.getOfflinePlayer(uuid), location)
-    
+
     fun canUse(tileEntity: TileEntity, location: Location) =
         canUse(tileEntity.owner, location)
     

--- a/Nova/src/main/kotlin/xyz/xenondevs/nova/tileentity/impl/agriculture/Fertilizer.kt
+++ b/Nova/src/main/kotlin/xyz/xenondevs/nova/tileentity/impl/agriculture/Fertilizer.kt
@@ -139,7 +139,7 @@ class Fertilizer(
     private fun getRandomPlant(): Block? =
         fertilizeRegion.blocks
             .filter {
-                ProtectionManager.canUse(ownerUUID, it.location)
+                ProtectionManager.canUse(owner, it.location)
                     && ((it.blockData is Ageable && !it.isFullyAged()) || (it.blockData !is Ageable && it.type in PlantUtils.PLANTS))
             }
             .randomOrNull()

--- a/Nova/src/main/kotlin/xyz/xenondevs/nova/tileentity/impl/agriculture/Fertilizer.kt
+++ b/Nova/src/main/kotlin/xyz/xenondevs/nova/tileentity/impl/agriculture/Fertilizer.kt
@@ -139,7 +139,7 @@ class Fertilizer(
     private fun getRandomPlant(): Block? =
         fertilizeRegion.blocks
             .filter {
-                ProtectionManager.canUse(owner, it.location)
+                ProtectionManager.canUse(this, it.location)
                     && ((it.blockData is Ageable && !it.isFullyAged()) || (it.blockData !is Ageable && it.type in PlantUtils.PLANTS))
             }
             .randomOrNull()

--- a/Nova/src/main/kotlin/xyz/xenondevs/nova/tileentity/impl/agriculture/Planter.kt
+++ b/Nova/src/main/kotlin/xyz/xenondevs/nova/tileentity/impl/agriculture/Planter.kt
@@ -161,7 +161,7 @@ class Planter(
             
             // Search for a block that has no block on top of it and is dirt/farmland
             // If the soil or plant block is protected, skip this block
-            if (!ProtectionManager.canPlace(ownerUUID, block.location) || !ProtectionManager.canBreak(ownerUUID, soilBlock.location))
+            if (!ProtectionManager.canPlace(owner, block.location) || !ProtectionManager.canBreak(owner, soilBlock.location))
                 return@indexOfFirst false
             
             // If the plant block is already occupied return false

--- a/Nova/src/main/kotlin/xyz/xenondevs/nova/tileentity/impl/agriculture/Planter.kt
+++ b/Nova/src/main/kotlin/xyz/xenondevs/nova/tileentity/impl/agriculture/Planter.kt
@@ -161,7 +161,7 @@ class Planter(
             
             // Search for a block that has no block on top of it and is dirt/farmland
             // If the soil or plant block is protected, skip this block
-            if (!ProtectionManager.canPlace(owner, block.location) || !ProtectionManager.canBreak(owner, soilBlock.location))
+            if (!ProtectionManager.canPlace(this, block.location) || !ProtectionManager.canBreak(this, soilBlock.location))
                 return@indexOfFirst false
             
             // If the plant block is already occupied return false

--- a/Nova/src/main/kotlin/xyz/xenondevs/nova/tileentity/impl/world/BlockPlacer.kt
+++ b/Nova/src/main/kotlin/xyz/xenondevs/nova/tileentity/impl/world/BlockPlacer.kt
@@ -76,7 +76,7 @@ class BlockPlacer(
             && !inventory.isEmpty
             && type == Material.AIR
             && TileEntityManager.getTileEntityAt(placeLocation) == null
-            && ProtectionManager.canPlace(ownerUUID, placeBlock.location)
+            && ProtectionManager.canPlace(owner, placeBlock.location)
         ) {
             if (placeBlock()) energyHolder.energy -= energyHolder.energyConsumption
         }

--- a/Nova/src/main/kotlin/xyz/xenondevs/nova/tileentity/impl/world/BlockPlacer.kt
+++ b/Nova/src/main/kotlin/xyz/xenondevs/nova/tileentity/impl/world/BlockPlacer.kt
@@ -76,7 +76,7 @@ class BlockPlacer(
             && !inventory.isEmpty
             && type == Material.AIR
             && TileEntityManager.getTileEntityAt(placeLocation) == null
-            && ProtectionManager.canPlace(owner, placeBlock.location)
+            && ProtectionManager.canPlace(this, placeBlock.location)
         ) {
             if (placeBlock()) energyHolder.energy -= energyHolder.energyConsumption
         }

--- a/Nova/src/main/kotlin/xyz/xenondevs/nova/tileentity/impl/world/Pump.kt
+++ b/Nova/src/main/kotlin/xyz/xenondevs/nova/tileentity/impl/world/Pump.kt
@@ -160,7 +160,7 @@ class Pump(
             val newBlock = newLocation.block
             
             val fluidType = newBlock.sourceFluidType ?: continue
-            if (fluidTank.accepts(fluidType) && newLocation.center() in region && ProtectionManager.canBreak(owner, newBlock.location)) {
+            if (fluidTank.accepts(fluidType) && newLocation.center() in region && ProtectionManager.canBreak(this, newBlock.location)) {
                 if (face !in VERTICAL_FACES)
                     sortedFaces.rotateRight()
                 block = newBlock
@@ -176,7 +176,7 @@ class Pump(
             if (r == 0) {
                 val block = location.clone().advance(BlockFace.DOWN).block
                 val fluidType = block.sourceFluidType ?: return@repeat
-                if (fluidTank.accepts(fluidType) && ProtectionManager.canBreak(owner, block.location))
+                if (fluidTank.accepts(fluidType) && ProtectionManager.canBreak(this, block.location))
                     return block to fluidType
                 return@repeat
             }
@@ -187,7 +187,7 @@ class Pump(
                             continue
                         val block = location.clone().add(x.toDouble(), y.toDouble(), z.toDouble()).block
                         val fluidType = block.sourceFluidType ?: continue
-                        if (fluidTank.accepts(fluidType) && ProtectionManager.canBreak(owner, block.location))
+                        if (fluidTank.accepts(fluidType) && ProtectionManager.canBreak(this, block.location))
                             return block to fluidType
                     }
                 }

--- a/Nova/src/main/kotlin/xyz/xenondevs/nova/tileentity/impl/world/Pump.kt
+++ b/Nova/src/main/kotlin/xyz/xenondevs/nova/tileentity/impl/world/Pump.kt
@@ -160,7 +160,7 @@ class Pump(
             val newBlock = newLocation.block
             
             val fluidType = newBlock.sourceFluidType ?: continue
-            if (fluidTank.accepts(fluidType) && newLocation.center() in region && ProtectionManager.canBreak(ownerUUID, newBlock.location)) {
+            if (fluidTank.accepts(fluidType) && newLocation.center() in region && ProtectionManager.canBreak(owner, newBlock.location)) {
                 if (face !in VERTICAL_FACES)
                     sortedFaces.rotateRight()
                 block = newBlock
@@ -176,7 +176,7 @@ class Pump(
             if (r == 0) {
                 val block = location.clone().advance(BlockFace.DOWN).block
                 val fluidType = block.sourceFluidType ?: return@repeat
-                if (fluidTank.accepts(fluidType) && ProtectionManager.canBreak(ownerUUID, block.location))
+                if (fluidTank.accepts(fluidType) && ProtectionManager.canBreak(owner, block.location))
                     return block to fluidType
                 return@repeat
             }
@@ -187,7 +187,7 @@ class Pump(
                             continue
                         val block = location.clone().add(x.toDouble(), y.toDouble(), z.toDouble()).block
                         val fluidType = block.sourceFluidType ?: continue
-                        if (fluidTank.accepts(fluidType) && ProtectionManager.canBreak(ownerUUID, block.location))
+                        if (fluidTank.accepts(fluidType) && ProtectionManager.canBreak(owner, block.location))
                             return block to fluidType
                     }
                 }

--- a/Nova/src/main/kotlin/xyz/xenondevs/nova/tileentity/impl/world/Quarry.kt
+++ b/Nova/src/main/kotlin/xyz/xenondevs/nova/tileentity/impl/world/Quarry.kt
@@ -10,6 +10,7 @@ import net.md_5.bungee.api.ChatColor
 import net.md_5.bungee.api.chat.TranslatableComponent
 import org.bukkit.Axis
 import org.bukkit.Location
+import org.bukkit.OfflinePlayer
 import org.bukkit.block.Block
 import org.bukkit.block.BlockFace
 import org.bukkit.entity.Player
@@ -179,7 +180,7 @@ class Quarry(
         
         updateEnergyPerTick()
         
-        if (checkPermission && !canPlace(ownerUUID, location, positions)) {
+        if (checkPermission && !canPlace(owner, location, positions)) {
             if (sizeX == MIN_SIZE && sizeZ == MIN_SIZE) {
                 TileEntityManager.destroyAndDropTileEntity(this, true)
                 return false
@@ -517,10 +518,10 @@ class Quarry(
     companion object {
         
         fun canPlace(player: Player, location: Location): Boolean {
-            return canPlace(player.uniqueId, location, location.yaw, MIN_SIZE, MIN_SIZE)
+            return canPlace(player, location, location.yaw, MIN_SIZE, MIN_SIZE)
         }
         
-        private fun canPlace(uuid: UUID, location: Location, yaw: Float, sizeX: Int, sizeZ: Int): Boolean {
+        private fun canPlace(owner: OfflinePlayer, location: Location, yaw: Float, sizeX: Int, sizeZ: Int): Boolean {
             val positions = getMinMaxPositions(
                 location,
                 sizeX, sizeZ,
@@ -528,15 +529,15 @@ class Quarry(
                 BlockSide.RIGHT.getBlockFace(yaw)
             )
             
-            return canPlace(uuid, location, positions)
+            return canPlace(owner, location, positions)
         }
         
-        private fun canPlace(uuid: UUID, location: Location, positions: IntArray): Boolean {
+        private fun canPlace(owner: OfflinePlayer, location: Location, positions: IntArray): Boolean {
             val minLoc = Location(location.world, positions[0].toDouble(), location.y, positions[1].toDouble())
             val maxLoc = Location(location.world, positions[2].toDouble(), location.y, positions[3].toDouble())
             
             minLoc.fullCuboidTo(maxLoc) {
-                if (ProtectionManager.canBreak(uuid, it))
+                if (ProtectionManager.canBreak(owner, it))
                     return@fullCuboidTo true
                 else return@canPlace false
             }


### PR DESCRIPTION
Use the cached OfflinePlayer owner field instead, Bukkit.getOfflinePlayer was a bit too "hot" in my spark reports.