### PR TITLE
Fix view history queueing same items

### DIFF
--- a/nova/src/main/kotlin/xyz/xenondevs/nova/ui/menu/item/ItemMenu.kt
+++ b/nova/src/main/kotlin/xyz/xenondevs/nova/ui/menu/item/ItemMenu.kt
@@ -12,6 +12,8 @@ internal interface ItemMenu {
         
         fun addToHistory(uuid: UUID, menu: ItemMenu) {
             val userHistory = itemMenuHistory.getOrPut(uuid) { LinkedList() }
+            if (userHistory.peekLast() == menu)
+                return
             userHistory += menu
             if (userHistory.size >= 10) userHistory.removeFirst()
         }


### PR DESCRIPTION
Can't confirm it's working, sorry.
I don't know if checking two classes via interface in kotlin ever return true if they're created separately...

The bug that I wanted to fix is that if you click on the result item many times in recipe window, then when you go back, it'll go back to the same item as many times as you clicked on it.

If I didn't manage to fix it, I'm sorry, please fix this bug on my behalf~