### PR TITLE
Fix AddonTask dependency coordinate lookup

### DIFF
--- a/nova-gradle-plugin/src/main/kotlin/xyz/xenondevs/novagradle/task/AddonTask.kt
+++ b/nova-gradle-plugin/src/main/kotlin/xyz/xenondevs/novagradle/task/AddonTask.kt
@@ -110,7 +110,7 @@ abstract class AddonTask : DefaultTask() {
     }
     
     private fun getArtifactCoords(dependency: DefaultExternalModuleDependency): String {
-        val artifact = dependency.artifacts.first()
+        val artifact = dependency.artifacts.firstOrNull()
         return if (artifact != null)
             "${dependency.group}:${dependency.name}:${artifact.extension}:${artifact.classifier}:${dependency.version}"
         else "${dependency.group}:${dependency.name}:${dependency.version}"


### PR DESCRIPTION
Currently, in
```

        val artifact = dependency.artifacts.first()
        return if (artifact != null)
            "${dependency.group}:${dependency.name}:${artifact.extension}:${artifact.classifier}:${dependency.version}"
        else "${dependency.group}:${dependency.name}:${dependency.version}"
```
It checks if there is an artifact in the dependency's artifacts, and returns one of two possible formats. However, the `artifact` will never be null, since `.first()` will throw an error if the collection is empty, rather than returning null. This pull request changes the `first` call into a `firstOrNull` to have the variable be null if the collection is empty, and make the method work properly.