### PR TITLE
Allow more shaped recipe sizes

### DIFF
--- a/nova/src/main/kotlin/xyz/xenondevs/nova/data/recipe/NovaCraftingRecipes.kt
+++ b/nova/src/main/kotlin/xyz/xenondevs/nova/data/recipe/NovaCraftingRecipes.kt
@@ -54,9 +54,9 @@ internal class NovaShapedRecipe(private val optimizedRecipe: OptimizedShapedReci
                 // If relX and relY are in the shape, it will be the RecipeChoice at that position, or null otherwise
                 val choice = if ((0 until width).contains(relX) && (0 until height).contains(relY))
                     optimizedRecipe.choiceMatrix.getOrNull(
-                    if (horizontalFlip) width * (relY + 1) - relX - 1
-                    else relX + relY * width
-                ) else null
+                        if (horizontalFlip) width * (relY + 1) - relX - 1
+                        else relX + relY * width
+                    ) else null
                 // If choice is null, treat it as an air RecipeChoice.
                 if (choice == null) {
                     if (!item.isEmpty) return false

--- a/nova/src/main/kotlin/xyz/xenondevs/nova/data/recipe/NovaCraftingRecipes.kt
+++ b/nova/src/main/kotlin/xyz/xenondevs/nova/data/recipe/NovaCraftingRecipes.kt
@@ -6,10 +6,7 @@ import net.minecraft.world.item.crafting.ShapedRecipe
 import net.minecraft.world.item.crafting.ShapelessRecipe
 import net.minecraft.world.item.crafting.SmeltingRecipe
 import net.minecraft.world.level.Level
-import org.bukkit.Material.*
 import org.bukkit.inventory.Recipe
-import org.bukkit.inventory.RecipeChoice
-import xyz.xenondevs.nova.ui.menu.item.recipes.createRecipeChoiceItem
 import xyz.xenondevs.nova.util.NonNullList
 import xyz.xenondevs.nova.util.bukkitCopy
 import xyz.xenondevs.nova.util.data.nmsCategory
@@ -52,7 +49,7 @@ internal class NovaShapedRecipe(private val optimizedRecipe: OptimizedShapedReci
                 val relY = absY - y
                 val item = container.getItem(absX + absY * container.width)
                 // If relX and relY are in the shape, it will be the RecipeChoice at that position, or null otherwise
-                val choice = if ((0 until width).contains(relX) && (0 until height).contains(relY))
+                val choice = if (relX in (0 until width) && relY in (0 until height))
                     optimizedRecipe.choiceMatrix.getOrNull(
                         if (horizontalFlip) width * (relY + 1) - relX - 1
                         else relX + relY * width

--- a/nova/src/main/kotlin/xyz/xenondevs/nova/data/recipe/RecipeManager.kt
+++ b/nova/src/main/kotlin/xyz/xenondevs/nova/data/recipe/RecipeManager.kt
@@ -331,7 +331,7 @@ internal class OptimizedShapedRecipe(val recipe: ShapedRecipe) {
     
     init {
         val flatShape = recipe.shape.joinToString("")
-        choiceMatrix = Array(9) { recipe.choiceMap[flatShape[it]] }
+        choiceMatrix = Array(flatShape.length) { recipe.choiceMap[flatShape[it]] }
         requiredChoices = flatShape.mapNotNull { recipe.choiceMap[it] }
         key = (recipe as Keyed).key.toString()
     }

--- a/nova/src/main/kotlin/xyz/xenondevs/nova/util/data/RecipeUtils.kt
+++ b/nova/src/main/kotlin/xyz/xenondevs/nova/util/data/RecipeUtils.kt
@@ -6,6 +6,7 @@ import org.bukkit.NamespacedKey
 import org.bukkit.inventory.*
 import org.bukkit.inventory.recipe.CookingBookCategory
 import org.bukkit.inventory.recipe.CraftingBookCategory
+import xyz.xenondevs.nova.data.recipe.CustomRecipeChoice
 import xyz.xenondevs.nova.material.PacketItems
 import xyz.xenondevs.nova.util.NonNullList
 import xyz.xenondevs.nova.util.nmsCopy


### PR DESCRIPTION
Currently, Nova only supports 3x3 shaped recipes. However, vanilla and bukkit actually supports many other shapes natively, such as 2x3, 3x2, 3x1, 1x3, etc. This pull request allows Nova to take advantage of the native recipe sizes, and allows other shaped recipe sizes to be used.