### PR TITLE
Fix addon dependency class resolution

### DIFF
--- a/nova/src/main/kotlin/xyz/xenondevs/nova/addon/loader/AddonClassLoader.kt
+++ b/nova/src/main/kotlin/xyz/xenondevs/nova/addon/loader/AddonClassLoader.kt
@@ -32,7 +32,7 @@ internal class AddonClassLoader(private val loader: AddonLoader, parent: ClassLo
             
             // Load class from addon dependencies
             if (c == null) {
-                c = addonDependencies?.firstNotNullOfOrNull { it.loadClass(name, true) }
+                c = addonDependencies?.firstNotNullOfOrNull { runCatching { it.loadClass(name, true) }.getOrNull() }
             }
             
             // load class from parent (nova classloader)


### PR DESCRIPTION
This pull request fixes accessing a class in a dependency of an addon. Currently, when looking through the ClassLoaders of the dependencies of an addon, the exception thrown by loadClass is not caught, which causes all remaining class loaders to be ignored, including other addon class loaders. This pull request fixes it by wrapping it in a runCatching block.