### PR TITLE
Support tags as recipe choices in recipes

### DIFF
--- a/nova/src/main/kotlin/xyz/xenondevs/nova/data/recipe/RecipeManager.kt
+++ b/nova/src/main/kotlin/xyz/xenondevs/nova/data/recipe/RecipeManager.kt
@@ -6,6 +6,7 @@ import org.bukkit.Bukkit
 import org.bukkit.Keyed
 import org.bukkit.Material
 import org.bukkit.NamespacedKey
+import org.bukkit.Tag
 import org.bukkit.entity.Player
 import org.bukkit.event.EventHandler
 import org.bukkit.event.EventPriority
@@ -64,10 +65,10 @@ class ModelDataTest(private val type: Material, private val data: IntArray, over
     
 }
 
-class MultiModelDataTest(private val types: Set<Material>, private val data: IntArray, override val examples: List<ItemStack>) : MultiItemTest {
+class TagTest(private val tag: Tag<Material>, private val data: IntArray, override val examples: List<ItemStack> = tag.values.map(::ItemStack)) : MultiItemTest {
     
     override fun test(item: ItemStack): Boolean {
-        return item.type in types && item.customModelData in data
+        return tag.isTagged(item.type) && item.customModelData in data
     }
     
 }

--- a/nova/src/main/kotlin/xyz/xenondevs/nova/data/recipe/RecipeManager.kt
+++ b/nova/src/main/kotlin/xyz/xenondevs/nova/data/recipe/RecipeManager.kt
@@ -65,10 +65,10 @@ class ModelDataTest(private val type: Material, private val data: IntArray, over
     
 }
 
-class TagTest(private val tag: Tag<Material>, private val data: IntArray, override val examples: List<ItemStack> = tag.values.map(::ItemStack)) : MultiItemTest {
+class TagTest(private val tag: Tag<Material>, override val examples: List<ItemStack> = tag.values.map(::ItemStack)) : MultiItemTest {
     
     override fun test(item: ItemStack): Boolean {
-        return tag.isTagged(item.type) && item.customModelData in data
+        return tag.isTagged(item.type) && item.customModelData == 0
     }
     
 }

--- a/nova/src/main/kotlin/xyz/xenondevs/nova/data/recipe/RecipeManager.kt
+++ b/nova/src/main/kotlin/xyz/xenondevs/nova/data/recipe/RecipeManager.kt
@@ -64,6 +64,14 @@ class ModelDataTest(private val type: Material, private val data: IntArray, over
     
 }
 
+class MultiModelDataTest(private val types: Set<Material>, private val data: IntArray, override val examples: List<ItemStack>) : MultiItemTest {
+    
+    override fun test(item: ItemStack): Boolean {
+        return item.type in types && item.customModelData in data
+    }
+    
+}
+
 class NovaIdTest(private val id: String, override val example: ItemStack) : SingleItemTest {
     
     override fun test(item: ItemStack): Boolean {

--- a/nova/src/main/kotlin/xyz/xenondevs/nova/data/serialization/json/RecipeDeserializer.kt
+++ b/nova/src/main/kotlin/xyz/xenondevs/nova/data/serialization/json/RecipeDeserializer.kt
@@ -47,23 +47,19 @@ interface RecipeDeserializer<T> {
             
             return parseRecipeChoice(list)
         }
-    
+        
         fun parseRecipeChoice(list: List<String>): RecipeChoice {
             val names = list.map { ids ->
                 // Id fallbacks
                 ids.replace(" ", "")
                     .split(';')
                     .firstOrNull {
-                        if (it.startsWith('#'))
-                            Bukkit.getTag(
-                                Tag.REGISTRY_ITEMS,
-                                NamespacedKey.fromString(it.substringAfter('#'))
-                                    ?: throw IllegalArgumentException("Malformed tag: $it"),
-                                Material::class.java
-                            ) != null
-                        else ItemUtils.isIdRegistered(it.substringBefore('{'))
-                    }
-                    ?: throw IllegalArgumentException("Invalid item id(s): $ids")
+                        if (it.startsWith('#')) {
+                            val tagName = NamespacedKey.fromString(it.substringAfter('#'))
+                                ?: throw IllegalArgumentException("Malformed tag: $it")
+                            return@firstOrNull Bukkit.getTag(Tag.REGISTRY_ITEMS, tagName, Material::class.java) != null
+                        } else ItemUtils.isIdRegistered(it.substringBefore('{'))
+                    } ?: throw IllegalArgumentException("Invalid item id(s): $ids")
             }
             
             return ItemUtils.getRecipeChoice(names)

--- a/nova/src/main/kotlin/xyz/xenondevs/nova/util/item/ItemUtils.kt
+++ b/nova/src/main/kotlin/xyz/xenondevs/nova/util/item/ItemUtils.kt
@@ -8,6 +8,7 @@ import net.minecraft.nbt.CompoundTag
 import net.minecraft.nbt.ListTag
 import net.minecraft.nbt.Tag
 import net.minecraft.world.item.Items
+import org.bukkit.Bukkit
 import org.bukkit.Material
 import org.bukkit.NamespacedKey
 import org.bukkit.craftbukkit.v1_19_R2.inventory.CraftItemStack
@@ -19,6 +20,7 @@ import xyz.xenondevs.nova.data.NamespacedId
 import xyz.xenondevs.nova.data.recipe.ComplexTest
 import xyz.xenondevs.nova.data.recipe.CustomRecipeChoice
 import xyz.xenondevs.nova.data.recipe.ModelDataTest
+import xyz.xenondevs.nova.data.recipe.MultiModelDataTest
 import xyz.xenondevs.nova.data.recipe.NovaIdTest
 import xyz.xenondevs.nova.data.recipe.NovaNameTest
 import xyz.xenondevs.nova.data.serialization.persistentdata.get
@@ -173,6 +175,17 @@ object ItemUtils {
     fun getRecipeChoice(nameList: List<String>): RecipeChoice {
         val tests = nameList.map { id ->
             try {
+                if (id.startsWith("#")) {
+                    val tagValues = Bukkit.getTag(
+                        org.bukkit.Tag.REGISTRY_ITEMS,
+                        NamespacedKey.fromString(id.substringAfter('#'))
+                            ?: throw IllegalArgumentException("Malformed tag: $id"),
+                        Material::class.java
+                    )?.values ?: throw IllegalArgumentException("Invalid tag: $id")
+                    return@map MultiModelDataTest(tagValues, intArrayOf(0), tagValues.map(::ItemStack).toList())
+                }
+                
+                
                 if (id.contains("{"))
                     return@map ComplexTest(toItemStack(id))
                 

--- a/nova/src/main/kotlin/xyz/xenondevs/nova/util/item/ItemUtils.kt
+++ b/nova/src/main/kotlin/xyz/xenondevs/nova/util/item/ItemUtils.kt
@@ -181,7 +181,7 @@ object ItemUtils {
                         ?: throw IllegalArgumentException("Malformed tag: $id")
                     val tag = Bukkit.getTag(Tag.REGISTRY_ITEMS, tagName, Material::class.java)
                         ?: throw IllegalArgumentException("Invalid tag: $id")
-                    return@map TagTest(tag, intArrayOf(0))
+                    return@map TagTest(tag)
                 }
                 
                 if (id.contains("{"))

--- a/nova/src/main/kotlin/xyz/xenondevs/nova/util/item/ItemUtils.kt
+++ b/nova/src/main/kotlin/xyz/xenondevs/nova/util/item/ItemUtils.kt
@@ -20,9 +20,9 @@ import xyz.xenondevs.nova.data.NamespacedId
 import xyz.xenondevs.nova.data.recipe.ComplexTest
 import xyz.xenondevs.nova.data.recipe.CustomRecipeChoice
 import xyz.xenondevs.nova.data.recipe.ModelDataTest
-import xyz.xenondevs.nova.data.recipe.MultiModelDataTest
 import xyz.xenondevs.nova.data.recipe.NovaIdTest
 import xyz.xenondevs.nova.data.recipe.NovaNameTest
+import xyz.xenondevs.nova.data.recipe.TagTest
 import xyz.xenondevs.nova.data.serialization.persistentdata.get
 import xyz.xenondevs.nova.data.serialization.persistentdata.set
 import xyz.xenondevs.nova.integration.customitems.CustomItemServiceManager
@@ -179,11 +179,10 @@ object ItemUtils {
                 if (id.startsWith("#")) {
                     val tagName = NamespacedKey.fromString(id.substringAfter('#'))
                         ?: throw IllegalArgumentException("Malformed tag: $id")
-                    val tagValues = Bukkit.getTag(Tag.REGISTRY_ITEMS, tagName, Material::class.java)?.values
+                    val tag = Bukkit.getTag(Tag.REGISTRY_ITEMS, tagName, Material::class.java)
                         ?: throw IllegalArgumentException("Invalid tag: $id")
-                    return@map MultiModelDataTest(tagValues, intArrayOf(0), tagValues.map(::ItemStack))
+                    return@map TagTest(tag, intArrayOf(0))
                 }
-                
                 
                 if (id.contains("{"))
                     return@map ComplexTest(toItemStack(id))

--- a/nova/src/main/kotlin/xyz/xenondevs/nova/util/item/ItemUtils.kt
+++ b/nova/src/main/kotlin/xyz/xenondevs/nova/util/item/ItemUtils.kt
@@ -6,11 +6,11 @@ import net.minecraft.commands.arguments.item.ItemParser
 import net.minecraft.core.registries.BuiltInRegistries
 import net.minecraft.nbt.CompoundTag
 import net.minecraft.nbt.ListTag
-import net.minecraft.nbt.Tag
 import net.minecraft.world.item.Items
 import org.bukkit.Bukkit
 import org.bukkit.Material
 import org.bukkit.NamespacedKey
+import org.bukkit.Tag
 import org.bukkit.craftbukkit.v1_19_R2.inventory.CraftItemStack
 import org.bukkit.inventory.ItemStack
 import org.bukkit.inventory.RecipeChoice
@@ -29,6 +29,7 @@ import xyz.xenondevs.nova.integration.customitems.CustomItemServiceManager
 import xyz.xenondevs.nova.material.ItemNovaMaterial
 import xyz.xenondevs.nova.material.NovaMaterialRegistry
 import xyz.xenondevs.nova.util.reflection.ReflectionRegistry
+import net.minecraft.nbt.Tag as NBTTag
 import net.minecraft.world.item.ItemStack as MojangStack
 
 val ItemStack.novaMaterial: ItemNovaMaterial?
@@ -82,8 +83,8 @@ val ItemStack.novaMaxStackSize: Int
     get() = novaMaterial?.maxStackSize ?: type.maxStackSize
 
 @Suppress("UNCHECKED_CAST")
-val ItemMeta.unhandledTags: MutableMap<String, Tag>
-    get() = ReflectionRegistry.CRAFT_META_ITEM_UNHANDLED_TAGS_FIELD.get(this) as MutableMap<String, Tag>
+val ItemMeta.unhandledTags: MutableMap<String, NBTTag>
+    get() = ReflectionRegistry.CRAFT_META_ITEM_UNHANDLED_TAGS_FIELD.get(this) as MutableMap<String, NBTTag>
 
 val ItemStack.canDestroy: List<Material>
     get() {
@@ -176,13 +177,11 @@ object ItemUtils {
         val tests = nameList.map { id ->
             try {
                 if (id.startsWith("#")) {
-                    val tagValues = Bukkit.getTag(
-                        org.bukkit.Tag.REGISTRY_ITEMS,
-                        NamespacedKey.fromString(id.substringAfter('#'))
-                            ?: throw IllegalArgumentException("Malformed tag: $id"),
-                        Material::class.java
-                    )?.values ?: throw IllegalArgumentException("Invalid tag: $id")
-                    return@map MultiModelDataTest(tagValues, intArrayOf(0), tagValues.map(::ItemStack).toList())
+                    val tagName = NamespacedKey.fromString(id.substringAfter('#'))
+                        ?: throw IllegalArgumentException("Malformed tag: $id")
+                    val tagValues = Bukkit.getTag(Tag.REGISTRY_ITEMS, tagName, Material::class.java)?.values
+                        ?: throw IllegalArgumentException("Invalid tag: $id")
+                    return@map MultiModelDataTest(tagValues, intArrayOf(0), tagValues.map(::ItemStack))
                 }
                 
                 


### PR DESCRIPTION
This allows recipes to use the built in Minecraft tags in recipe ingredients. This makes it significantly easier to create recipes with certain ingredients, such as an "any plank" recipe choice, "any stair", etc.

For example, previously, to make a recipe that used any planks, the recipe would look similar to this:

```json
{
  "result": "placeholder:placeholder",
  "shape": [
    "www",
    "wsw",
    "www"
  ],
  "ingredients": {
    "w": ["minecraft:oak_planks","minecraft:birch_planks","minecraft:spruce_planks", "minecraft:jungle_planks", ...etc],
    "s": "minecraft:stone"
  }
}
```
Now with this pull request, it can be written as:
This allows recipes to use the built in Minecraft tags in recipe ingredients. This makes it significantly easier to create recipes with certain ingredients, such as an "any plank" recipe choice, "any stair", etc.

For example, previously, to make a recipe that used any planks, the recipe would look similar to this:

```json
{
  "result": "placeholder:placeholder",
  "shape": [
    "www",
    "wsw",
    "www"
  ],
  "ingredients": {
    "w": "#minecraft:planks",
    "s": "minecraft:stone"
  }
}
```
Using the #planks tag (https://minecraft.fandom.com/wiki/Tag#Items).