### PR TITLE
Fix creative mode item list filtering

### DIFF
--- a/nova/src/main/kotlin/xyz/xenondevs/nova/material/PacketItems.kt
+++ b/nova/src/main/kotlin/xyz/xenondevs/nova/material/PacketItems.kt
@@ -314,12 +314,10 @@ internal object PacketItems : Initializable(), Listener {
         val stream = NBTUtils.convertListToStream(list)
         stream.forEach { contentItem ->
             val compound = CompoundTag()
-            
             if (isContainerItem(contentItem)) {
                 filterContainerItems(contentItem, fromCreative).save(compound)
-            } else if (fromCreative) {
-                if (isFakeItem(contentItem)) // Don't collapse if statement to prevent isNovaItem call
-                    getNovaItem(contentItem).save(compound)
+            } else if (fromCreative && isFakeItem(contentItem)) {
+                getNovaItem(contentItem).save(compound)
             } else if (isNovaItem(contentItem)) {
                 getFakeItem(null, contentItem).save(compound)
             } else {


### PR DESCRIPTION
Currently when container items are filtered in creative mode, the code responsible for filtering the contents of container items while in creative will unintentionally delete vanilla items from the container. This can be reproduced by going into survival, filling up a bundle with 1 vanilla item and 1 nova item, then going into creative and checking the item while in creative. 
This is caused by the following code:
```kt
            } else if (fromCreative) {
                if (isFakeItem(contentItem)) // Don't collapse if statement to prevent isNovaItem call
                    getNovaItem(contentItem).save(compound)
            } 
```
If `fromCreative` is set and `isFakeItem` is false (i.e. the item is a vanilla item), nothing will be saved to the compound tag, and the item will be written as `{}`. This causes the vanilla items to disappear.
This pull request solves it by collapsing the if statement into
```kt
            } else if (fromCreative && isFakeItem(contentItem)) {
                getNovaItem(contentItem).save(compound)
            }
```
The comment states that collapsing the if statement will cause an isNovaItem call, but having the nova packet item be sent to a creative client will not cause the item on the server to be written as the client-side item due to the creative set-slot packet having its item changed to the real server-side item.