### PR TITLE
Allow item categories to be marked as hidden

### DIFF
--- a/nova/src/main/kotlin/xyz/xenondevs/nova/material/ItemCategories.kt
+++ b/nova/src/main/kotlin/xyz/xenondevs/nova/material/ItemCategories.kt
@@ -117,7 +117,7 @@ internal data class CategoryPriority(val addonId: String, val preferredPosition:
     
 }
 
-internal data class ItemCategory(val name: String, val icon: ItemProvider, val items: List<CategorizedItem>) {
+internal data class ItemCategory(val name: String, val icon: ItemProvider, val items: List<CategorizedItem>, val hidden: Boolean) {
     
     companion object {
         fun deserialize(element: ConfigurationSection): ItemCategory? {
@@ -127,8 +127,9 @@ internal data class ItemCategory(val name: String, val icon: ItemProvider, val i
                     .setDisplayName(TranslatableComponent(name))
                     .get()
                 val items = element.getStringList("items").map(::CategorizedItem)
+                val hidden = element.getBoolean("hidden", false)
                 
-                return ItemCategory(name, ItemWrapper(icon), items)
+                return ItemCategory(name, ItemWrapper(icon), items, hidden)
             } catch (e: Exception) {
                 LOGGER.log(Level.SEVERE, "Could not deserialize item category", e)
             }

--- a/nova/src/main/kotlin/xyz/xenondevs/nova/ui/menu/item/creative/ItemsWindow.kt
+++ b/nova/src/main/kotlin/xyz/xenondevs/nova/ui/menu/item/creative/ItemsWindow.kt
@@ -114,6 +114,7 @@ internal class ItemsWindow(val player: Player) : ItemMenu {
     
     init {
         val tabButtons = ItemCategories.CATEGORIES
+            .filter { !it.hidden }
             .withIndex()
             .map { (index, category) -> CreativeTabItem(index, category).apply { setGui(mainGUI) } }
         tabPagesGUI.setItems(tabButtons)


### PR DESCRIPTION
Currently, in order for an item to be listed in /nova give, the item must be in an item category. However, having the item put in an item category also causes it to be listed in /nova items. This pull request allows item categories to be specified as hidden to have the item still listed in /nova give, but not shown in /nova items.