### PR TITLE
Register recipes from RecipeRegistry#addHardcodedRecipes

### DIFF
--- a/nova/src/main/kotlin/xyz/xenondevs/nova/data/recipe/RecipeManager.kt
+++ b/nova/src/main/kotlin/xyz/xenondevs/nova/data/recipe/RecipeManager.kt
@@ -148,58 +148,60 @@ object RecipeManager : Initializable(), Listener {
     }
     
     private fun loadRecipes() {
-        RecipesLoader.loadRecipes().forEach { recipe ->
-            when (recipe) {
-                is Recipe -> {
-                    val key = (recipe as Keyed).key
+        RecipesLoader.loadRecipes().forEach(::loadRecipe)
+    }
+    
+    fun loadRecipe(recipe: Any) {
+        when (recipe) {
+            is Recipe -> {
+                val key = (recipe as Keyed).key
+            
+                when (recipe) {
+                
+                    is ShapedRecipe -> {
+                        val optimizedRecipe = OptimizedShapedRecipe(recipe)
+                        shapedRecipes[key] = optimizedRecipe
                     
-                    when (recipe) {
-                        
-                        is ShapedRecipe -> {
-                            val optimizedRecipe = OptimizedShapedRecipe(recipe)
-                            shapedRecipes[key] = optimizedRecipe
-                            
-                            val nmsRecipe = NovaShapedRecipe(optimizedRecipe)
-                            minecraftServer.recipeManager.addRecipe(nmsRecipe)
-                            
-                            _clientsideRecipes[key] = nmsRecipe.clientsideCopy()
-                        }
-                        
-                        is ShapelessRecipe -> {
-                            shapelessRecipes[key] = recipe
-                            
-                            val nmsRecipe = NovaShapelessRecipe(recipe)
-                            minecraftServer.recipeManager.addRecipe(nmsRecipe)
-                            
-                            _clientsideRecipes[key] = nmsRecipe.clientsideCopy()
-                        }
-                        
-                        is FurnaceRecipe -> {
-                            furnaceRecipes[key] = recipe
-                            
-                            val nmsRecipe = NovaFurnaceRecipe(recipe)
-                            minecraftServer.recipeManager.addRecipe(nmsRecipe)
-                            
-                            _clientsideRecipes[key] = nmsRecipe.clientsideCopy()
-                        }
-                        
-                        is StonecuttingRecipe -> {
-                            Bukkit.addRecipe(recipe)
-                            
-                            _clientsideRecipes[key] = recipe.clientsideCopy()
-                        }
-                        
-                        else -> Bukkit.addRecipe(recipe)
+                        val nmsRecipe = NovaShapedRecipe(optimizedRecipe)
+                        minecraftServer.recipeManager.addRecipe(nmsRecipe)
+                    
+                        _clientsideRecipes[key] = nmsRecipe.clientsideCopy()
                     }
+                
+                    is ShapelessRecipe -> {
+                        shapelessRecipes[key] = recipe
                     
-                    registeredVanillaRecipeKeys += key
-                    customVanillaRecipeKeys += key
+                        val nmsRecipe = NovaShapelessRecipe(recipe)
+                        minecraftServer.recipeManager.addRecipe(nmsRecipe)
+                    
+                        _clientsideRecipes[key] = nmsRecipe.clientsideCopy()
+                    }
+                
+                    is FurnaceRecipe -> {
+                        furnaceRecipes[key] = recipe
+                    
+                        val nmsRecipe = NovaFurnaceRecipe(recipe)
+                        minecraftServer.recipeManager.addRecipe(nmsRecipe)
+                    
+                        _clientsideRecipes[key] = nmsRecipe.clientsideCopy()
+                    }
+                
+                    is StonecuttingRecipe -> {
+                        Bukkit.addRecipe(recipe)
+                    
+                        _clientsideRecipes[key] = recipe.clientsideCopy()
+                    }
+                
+                    else -> Bukkit.addRecipe(recipe)
                 }
-                
-                is NovaRecipe -> _novaRecipes.getOrPut(recipe.type) { HashMap() }[recipe.key] = recipe
-                
-                else -> throw UnsupportedOperationException("Unsupported Recipe Type: ${recipe::class.java}")
+            
+                registeredVanillaRecipeKeys += key
+                customVanillaRecipeKeys += key
             }
+        
+            is NovaRecipe -> _novaRecipes.getOrPut(recipe.type) { HashMap() }[recipe.key] = recipe
+        
+            else -> throw UnsupportedOperationException("Unsupported Recipe Type: ${recipe::class.java}")
         }
     }
     

--- a/nova/src/main/kotlin/xyz/xenondevs/nova/data/recipe/RecipeRegistry.kt
+++ b/nova/src/main/kotlin/xyz/xenondevs/nova/data/recipe/RecipeRegistry.kt
@@ -36,6 +36,7 @@ object RecipeRegistry : Initializable() {
     fun addHardcodedRecipes(recipes: List<NovaRecipe>) {
         check(!isInitialized) { "Recipes are already initialized" }
         hardcodedRecipes += recipes
+        recipes.forEach(RecipeManager::loadRecipe)
     }
     
     fun addCreationInfo(info: Map<String, String>) {
@@ -133,7 +134,7 @@ object RecipeRegistry : Initializable() {
     }
     
     private fun getAllNovaRecipes(): Sequence<NovaRecipe> {
-        return RecipeManager.novaRecipes.values.asSequence().flatMap { it.values } + hardcodedRecipes.asSequence()
+        return RecipeManager.novaRecipes.values.asSequence().flatMap { it.values }
     }
     
     private fun getCreationNovaRecipeSequence(): Sequence<ResultingRecipe> {


### PR DESCRIPTION
Currently, RecipeRegistry#addHardcodedRecipes will not register custom recipes into RecipeManager.novaRecipes. This causes implementing these recipes to either require duplicating the code for the recipes, once into addHardcodedRecipes and once into a different location for accessing the recipes, or storing list of nova recipes directly in a variable. Both of these ways makes interacting with these types of recipes significantly different than normal recipes where you can access the recipes at the RecipeManager through novaRecipes, getConversionRecipeFor, or other methods. This pull request registers these recipes into the RecipeManager so that they are accessible from the `novaRecipes` and the other methods of RecipeManager.