### PR TITLE
Fix base item models

### DIFF
--- a/nova/src/main/kotlin/xyz/xenondevs/nova/data/resources/builder/content/material/MaterialContent.kt
+++ b/nova/src/main/kotlin/xyz/xenondevs/nova/data/resources/builder/content/material/MaterialContent.kt
@@ -28,7 +28,6 @@ import xyz.xenondevs.nova.util.data.GSON
 import xyz.xenondevs.nova.util.data.parseJson
 import xyz.xenondevs.nova.util.mapToIntArray
 import java.io.File
-import java.nio.charset.StandardCharsets
 import kotlin.collections.component1
 import kotlin.collections.component2
 import kotlin.collections.set
@@ -252,7 +251,7 @@ internal class MaterialContent(
                     val textures = JsonObject().apply { addProperty("layer0", "item/${material.name.lowercase()}") }
                     modelObj.add("textures", textures)
                 } else {
-                    modelObj = GSON.fromJson(vanillaModel.reader(StandardCharsets.UTF_8), JsonObject::class.java)
+                    modelObj = vanillaModel.parseJson() as JsonObject
                 }
             }
             

--- a/nova/src/main/kotlin/xyz/xenondevs/nova/data/resources/builder/content/material/MaterialContent.kt
+++ b/nova/src/main/kotlin/xyz/xenondevs/nova/data/resources/builder/content/material/MaterialContent.kt
@@ -28,6 +28,7 @@ import xyz.xenondevs.nova.util.data.GSON
 import xyz.xenondevs.nova.util.data.parseJson
 import xyz.xenondevs.nova.util.mapToIntArray
 import java.io.File
+import java.nio.charset.StandardCharsets
 import kotlin.collections.component1
 import kotlin.collections.component2
 import kotlin.collections.set
@@ -239,15 +240,20 @@ internal class MaterialContent(
     private fun getModelFile(material: Material): Triple<File, JsonObject, JsonArray> {
         val file = File(ResourcePackBuilder.ASSETS_DIR, "minecraft/models/item/${material.name.lowercase()}.json")
         if (!file.exists()) {
-            val modelObj = JsonObject()
+            var modelObj = JsonObject()
             
             // fixme: This does not cover all cases
             if (material.isBlock) {
                 modelObj.addProperty("parent", "block/${material.name.lowercase()}")
             } else {
-                modelObj.addProperty("parent", "item/generated")
-                val textures = JsonObject().apply { addProperty("layer0", "item/${material.name.lowercase()}") }
-                modelObj.add("textures", textures)
+                val vanillaModel = File(ResourcePackBuilder.MCASSETS_ASSETS_DIR, "minecraft/models/item/${material.name.lowercase()}.json")
+                if (!vanillaModel.exists()) {
+                    modelObj.addProperty("parent", "item/generated")
+                    val textures = JsonObject().apply { addProperty("layer0", "item/${material.name.lowercase()}") }
+                    modelObj.add("textures", textures)
+                } else {
+                    modelObj = GSON.fromJson(vanillaModel.reader(StandardCharsets.UTF_8), JsonObject::class.java)
+                }
             }
             
             val overrides = JsonArray().also { modelObj.add("overrides", it) }


### PR DESCRIPTION
Currently, any vanilla material that has nova items which use it as a material will have their models set to extend item/generated, have their layer0 set to the item's texture, and have overrides set accordingly. However, this causes issues with models do not extend item/generated such as wooden tools (such as those used by nova for items with durability), items with multiple layers (firework stars, maps), and other item models that do not follow the generic generated item format. For example, Nova currently will turn wooden tools into generated models which cause their held model to be positioned incorrectly (wooden tools are normally item/handheld but nova changes them to item/generated). It also makes the second layer of models disappear if they have a second layer, such as removing the dots from the firework star. 

This pull request fixes these issues by making nova retrieve the vanilla item model and base the new edited model with overrides off of the vanilla model instead of making a new item/generated model for everything.