### PR TITLE
Disable experience drops in creative and with incorrect tool

### DIFF
--- a/nova/src/main/kotlin/xyz/xenondevs/nova/context/param/DefaultContextParamTypes.kt
+++ b/nova/src/main/kotlin/xyz/xenondevs/nova/context/param/DefaultContextParamTypes.kt
@@ -615,7 +615,8 @@ object DefaultContextParamTypes {
      * Optional in intentions:
      * - [BlockBreak]
      *
-     * Autofilled by: none
+     * Autofilled by:
+     * - [BLOCK_DROPS]
      *
      * Autofills: none
      *
@@ -625,6 +626,7 @@ object DefaultContextParamTypes {
     val BLOCK_EXP_DROPS: DefaultingContextParamType<Boolean> =
         ContextParamType.builder<Boolean>("block_exp_drops")
             .optionalIn(BlockBreak)
+            .autofilledBy(::BLOCK_DROPS) { it }
             .build(true)
     
     /**


### PR DESCRIPTION
Previously, all blocks (both custom and vanilla) dropped experience every time they were mined, even in cases where they shouldn't (in creative mode or when using an incorrect tool).

The `BLOCK_EXP_DROPS` context parameter is now autofilled based on `BLOCK_DROPS`, making it consistent with vanilla Minecraft behavior.