### PR TITLE
Removed legacy color code

### DIFF
--- a/nova/src/main/kotlin/xyz/xenondevs/nova/util/NumberFormatUtils.kt
+++ b/nova/src/main/kotlin/xyz/xenondevs/nova/util/NumberFormatUtils.kt
@@ -104,7 +104,7 @@ object NumberFormatUtils {
             .toPlainString()
         
         val prefixedUnit = "${prefix.prefixSymbol}$unit"
-        return "§r$prefixedNumber $prefixedUnit / $prefixedMaxNumber $prefixedUnit"
+        return "$prefixedNumber $prefixedUnit / $prefixedMaxNumber $prefixedUnit"
     }
     
     fun getRomanNumeral(number: Int): String {


### PR DESCRIPTION
https://github.com/xenondevs/Nova/issues/689
Avoid compatibility between legacy color codes with MiniMessage's format