### PR TITLE
Added url_style option for S3 to determine urlFormat

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version = 0.20.3
+version = 0.20.4
 kotlin.daemon.jvmargs=-Xmx2g
 org.gradle.jvmargs=-Xmx2g
 org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version = 0.20.4
+version = 0.20.4r
 kotlin.daemon.jvmargs=-Xmx2g
 org.gradle.jvmargs=-Xmx2g
 org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled

--- a/nova/src/main/kotlin/xyz/xenondevs/nova/resources/upload/service/S3.kt
+++ b/nova/src/main/kotlin/xyz/xenondevs/nova/resources/upload/service/S3.kt
@@ -72,22 +72,23 @@ internal object S3 : UploadService {
     }
     
     override suspend fun upload(file: Path): String {
-        val name = StringUtils.randomString(5)
+        val key = StringUtils.randomString(5)
         val req = PutObjectRequest.builder()
             .bucket(bucket)
-            .key(directory + name)
+            .key(directory + key)
             .build()
         val resp = client!!.putObject(req, file).sdkHttpResponse()
         
         if (!resp.isSuccessful)
             throw IllegalStateException("S3 upload failed with code ${resp.statusCode()} " + resp.statusText().orElse(""))
-        
-        val lastUpload: String? = PermanentStorage.retrieve("lastS3Upload")
-        if (lastUpload != null && lastUpload.startsWith(urlFormat.dropLast(2 + directory.length))) {
-            val lastBucket = lastUpload.drop("https://".length).split("/")[1]
+
+        val lastUrl: String? = PermanentStorage.retrieve("lastS3Url")
+        val lastBucket: String? = PermanentStorage.retrieve("lastS3Bucket")
+        val lastKey: String? = PermanentStorage.retrieve("lastS3Key")
+        if (lastUrl != null && lastUrl.startsWith(urlFormat.dropLast(2 + directory.length))) {
             val delReq = DeleteObjectRequest.builder()
                 .bucket(lastBucket)
-                .key(lastUpload.split('/', limit = 5).last())
+                .key(lastKey)
                 .build()
             
             val delResp = client!!.deleteObject(delReq)
@@ -96,8 +97,10 @@ internal object S3 : UploadService {
                     + delResp.sdkHttpResponse().statusText().orElse(""))
         }
         
-        val url = urlFormat.format(name)
-        PermanentStorage.store("lastS3Upload", url)
+        val url = urlFormat.format(key)
+        PermanentStorage.store("lastS3Url", url)
+        PermanentStorage.store("lastS3Bucket", bucket)
+        PermanentStorage.store("lastS3Key", key)
         return url
     }
     

--- a/nova/src/main/kotlin/xyz/xenondevs/nova/resources/upload/service/S3.kt
+++ b/nova/src/main/kotlin/xyz/xenondevs/nova/resources/upload/service/S3.kt
@@ -87,7 +87,7 @@ internal object S3 : UploadService {
             val lastBucket = lastUpload.drop("https://".length).split("/")[1]
             val delReq = DeleteObjectRequest.builder()
                 .bucket(lastBucket)
-                .key(lastUpload.split('/', limit = 5)[4])
+                .key(lastUpload.split('/', limit = 5).last())
                 .build()
             
             val delResp = client!!.deleteObject(delReq)

--- a/nova/src/main/kotlin/xyz/xenondevs/nova/util/NumberFormatUtils.kt
+++ b/nova/src/main/kotlin/xyz/xenondevs/nova/util/NumberFormatUtils.kt
@@ -104,7 +104,7 @@ object NumberFormatUtils {
             .toPlainString()
         
         val prefixedUnit = "${prefix.prefixSymbol}$unit"
-        return "§r$prefixedNumber $prefixedUnit / $prefixedMaxNumber $prefixedUnit"
+        return "$prefixedNumber $prefixedUnit / $prefixedMaxNumber $prefixedUnit"
     }
     
     fun getRomanNumeral(number: Int): String {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -32,6 +32,8 @@ dependencyResolutionManagement {
 
 pluginManagement {
     repositories {
+        maven("https://maven-central.storage-download.googleapis.com/maven2/")
+        maven("https://maven.aliyun.com/repository/public")
         mavenLocal { content { includeGroupAndSubgroups("xyz.xenondevs") } }
         mavenCentral()
         gradlePluginPortal()


### PR DESCRIPTION
<img width="1197" height="75" alt="image" src="https://github.com/user-attachments/assets/d59bc054-675c-4caf-8161-91859fceba48" />

it is found that the resource pack cannot be downloaded in the game, and the following results are obtained after using the browser to access it:

```xml
<Error>
  <Code>SecondLevelDomainForbidden</Code>
  <Message>The bucket you are attempting to access must be addressed using OSS third level domain.</Message>
  <RequestId>68B9... 1FA4</RequestId>
  <HostId>oss-cn-hangzhou.aliyuncs.com</HostId>
  <EC>00...01</EC>
  <RecommendDoc>https://api.xx.com/t..t?q=00..01</RecommendDoc>
</Error>
```

I initially wanted to try using `force_path_style` directly to determine the `urlFormat`, but then realized that the S3 SDK's `force_path_style` was not directly related to the format of the generated download address, so I added a new string enumeration parameter `url_style: "path" | "vhost"` to determine the value of `urlFormat`